### PR TITLE
Implement in-memory persistence of crawled pokemons

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,18 @@
   "main": "app.js",
   "dependencies": {
     "express": "^4.14.0",
+    "iterator-tools": "^1.0.0-dev.0",
     "long": "^3.2.0",
     "pokemon-go-node-api": "Armax/Pokemon-GO-node-api",
     "socket.io": "^1.4.8"
   },
   "scripts": {
     "lint": "eslint .",
-    "start": "node src/app.js"
+    "start": "node src/app.js",
+    "test": "ava"
+  },
+  "devDependencies": {
+    "ava": "^0.15.2",
+    "eslint": "^3.2.2"
   }
 }

--- a/src/__tests__/grid.js
+++ b/src/__tests__/grid.js
@@ -1,0 +1,86 @@
+const test = require('ava');
+const Grid = require('../grid');
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('Grid is a function', (t) => {
+    t.is(typeof Grid, 'function');
+});
+
+
+test('add a coordinate', (t) => {
+    const g = new Grid(10);
+    g.add({ latitude: 0, longitude: 0, data: 1 });
+    g.add({ latitude: 0.000002, longitude: 0, data: 2 });
+    g.add({ latitude: 1, longitude: 0, data: 3 });
+
+    t.deepEqual(Array.from(g.entries()), [
+        [
+            { latitude: 0, longitude: 0 },
+            [
+                { latitude: 0, longitude: 0, data: 1 },
+                { latitude: 0.000002, longitude: 0, data: 2 },
+            ],
+        ],
+        [
+            { latitude: 0.9999147427534394, longitude: 0 },
+            [
+                { latitude: 1, longitude: 0, data: 3 },
+            ],
+        ],
+    ]);
+});
+
+test('expiring coordinates', (t) => {
+    const g = new Grid(10);
+
+    const pastCoordinates = {
+        latitude: 0,
+        longitude: 0,
+        data: 1,
+        expiration: Date.now() - 1000
+    };
+
+    const futureCoordinates = {
+        latitude: 0,
+        longitude: 0,
+        data: 2,
+        expiration: Date.now() + 1000
+    };
+
+    g.add(pastCoordinates);
+    g.add(futureCoordinates);
+
+    t.deepEqual(Array.from(g.entries()), [
+        [
+            { latitude: 0, longitude: 0 },
+            [
+                futureCoordinates,
+            ],
+        ],
+    ]);
+});
+
+test('garbage collected coordinates', (t) => {
+    const g = new Grid(10);
+    g._garbageCollectorDelay = 10;
+
+    const pastCoordinates = {
+        latitude: 0,
+        longitude: 0,
+        data: 1,
+        expiration: Date.now() - 1000
+    };
+
+    g.add(pastCoordinates);
+
+    t.deepEqual(Array.from(g._map.values()), [ [ pastCoordinates ] ]);
+
+
+    return sleep(100)
+        .then(() => {
+            t.deepEqual(Array.from(g._map.values()), [ ]);
+        });
+});

--- a/src/coordinates.js
+++ b/src/coordinates.js
@@ -1,0 +1,19 @@
+const deg = 360 / (Math.PI * 2);
+const R = 6378137; // Radius of earth in meters
+
+function shift(coords, offsetX, offsetY) {
+    return {
+        latitude: coords.latitude  + (offsetY / R) * deg,
+        longitude: coords.longitude + (offsetX / R) * deg / Math.cos(coords.latitude * deg),
+    };
+}
+
+function floor(coords, delta) {
+    const deltaAngle = (delta / R) * deg;
+    return {
+        latitude: Math.floor(coords.latitude / deltaAngle) * deltaAngle,
+        longitude: Math.floor(coords.longitude / deltaAngle) * deltaAngle,
+    };
+}
+
+module.exports = { shift, floor };

--- a/src/grid.js
+++ b/src/grid.js
@@ -1,0 +1,70 @@
+const it = require('iterator-tools');
+const coordinates = require('./coordinates');
+
+function computeKey(coordinates) {
+    return `${coordinates.latitude.toFixed(10)},${coordinates.longitude.toFixed(10)}`;
+}
+
+function isAlive(object) {
+    return object.expiration === undefined || object.expiration > Date.now();
+}
+
+module.exports = class Grid {
+    constructor(delta) {
+        if (typeof delta !== 'number' || delta <= 0) throw new Error('Invalid delta');
+        this._delta = delta;
+        this._map = new Map();
+        this._collectorInterval = null;
+        this._garbageCollectorDelay = 60000;
+    }
+
+    _key(object) {
+        return computeKey(coordinates.floor(object, this._delta));
+    }
+
+    _stopGC() {
+        clearInterval(this._collectorInterval);
+        this._collectorInterval = null;
+    }
+
+    _startGC() {
+        if (this._collectorInterval === null) {
+            this._collectorInterval = setInterval(() => this._gc(), this._garbageCollectorDelay);
+        }
+    }
+
+    _gc() {
+        let aliveObjectCount = 0;
+
+        for (const [key, list] of this._map) {
+            const filteredList = list.filter(isAlive);
+            if (filteredList.length) this._map.set(key, filteredList);
+            else this._map.delete(key);
+            aliveObjectCount += filteredList.length;
+        }
+
+        if (aliveObjectCount === 0) this._stopGC();
+    }
+
+    add(object) {
+        if (typeof object.longitude !== 'number' || typeof object.latitude !== 'number') {
+            throw new Error('Invalid object');
+        }
+        const key = this._key(object);
+        let list = this._map.get(key);
+        if (!list) this._map.set(key, list = []);
+        list.push(object);
+        this._startGC();
+    }
+
+    entries() {
+        return it.map(
+            this._map.values(),
+            (list) => [ coordinates.floor(list[0], this._delta), list.filter(isAlive) ]
+        );
+    }
+
+    values() {
+        return it.map(this.entries(), (entry) => entry[1]);
+    }
+};


### PR DESCRIPTION
This introduces the Grid, aimed to store the pokémons (and maybe other
geo-localized informations). The Grid groups object in cells of 100x100
meters. This feature isn't used for now but should be used to have a
more intelligent crawler displacement (ex: have a "last update date" on
each grid cell).

Also, use iterators because it's fun.
